### PR TITLE
Fix: Update sed command to point to renamed files

### DIFF
--- a/.github/workflows/wf_build_archiso.yaml
+++ b/.github/workflows/wf_build_archiso.yaml
@@ -68,10 +68,10 @@ jobs:
           sed -i "s/initramfs-linux.img/initramfs-$kernel.img/" archiso_pxe-linux.cfg
 
           cd "$build"/efiboot/loader/entries
-          sed -i "s/vmlinuz-linux/vmlinuz-$kernel/" 01-archiso-x86_64-linux.conf
-          sed -i "s/initramfs-linux.img/initramfs-$kernel.img/" 01-archiso-x86_64-linux.conf
-          sed -i "s/vmlinuz-linux/vmlinuz-$kernel/" 02-archiso-x86_64-speech-linux.conf
-          sed -i "s/initramfs-linux.img/initramfs-$kernel.img/" 02-archiso-x86_64-speech-linux.conf
+          sed -i "s/vmlinuz-linux/vmlinuz-$kernel/" 01-archiso-linux.conf
+          sed -i "s/initramfs-linux.img/initramfs-$kernel.img/" 01-archiso-linux.conf
+          sed -i "s/vmlinuz-linux/vmlinuz-$kernel/" 02-archiso-speech-linux.conf
+          sed -i "s/initramfs-linux.img/initramfs-$kernel.img/" 02-archiso-speech-linux.conf
 
           cp "$build"/pacman.conf "$build"/airootfs/etc/pacman.conf
           mkdir -p "$build"/airootfs/usr/share/pacman/keyrings


### PR DESCRIPTION
Hello, thanks for putting this great tool together. It looks like the reason the last two monthly builds failed is some files supplied by the `archiso` package in `/usr/share/archiso/configs/releng/` were [renamed in a recent update](https://gitlab.archlinux.org/archlinux/archiso/-/commit/c7ca1f7b3c44c278eac0ed1c2add1ba51cabdd44)). All that seems to be required is removing the "x86_64" suffix from the corresponding sed commands. I successfully [built](https://github.com/broomej/archlinux-lts-zfs/actions/runs/19555353089) the [image](https://github.com/broomej/archlinux-lts-zfs/releases/tag/2025.11.21) with GH actions after incorporating these changes.